### PR TITLE
Link cuFFTMp before cuFFT

### DIFF
--- a/distributed/src/CMakeLists.txt
+++ b/distributed/src/CMakeLists.txt
@@ -5,15 +5,19 @@ find_package(MPI REQUIRED COMPONENTS CXX)
 target_link_libraries(distributed
     INTERFACE
     Kokkos::kokkos
-    KokkosFFT::fft
     MPI::MPI_CXX
 )
 
 if(ENABLE_CUFFT_MP AND Kokkos_ENABLE_CUDA)
   find_package(cuFFTMp REQUIRED)
   target_include_directories(distributed INTERFACE ${cuFFTMp_INCLUDE_DIRS})
+  # We link cuFFTMp before and after KokkosFFT to ensure that it will be linked before cuFFT
+  target_link_libraries(distributed INTERFACE ${cuFFTMp_LIBRARIES})
+  target_link_libraries(distributed INTERFACE KokkosFFT::fft)
   target_link_libraries(distributed INTERFACE ${cuFFTMp_LIBRARIES})
   target_compile_definitions(distributed INTERFACE ENABLE_TPL_CUFFT_MP PRIOTIZE_TPL_PLAN_IF_AVAILABLE)
+else()
+  target_link_libraries(distributed INTERFACE KokkosFFT::fft)
 endif()
 
 if(ENABLE_ROCFFT_MPI AND Kokkos_ENABLE_HIP AND KokkosFFT_ENABLE_ROCFFT)

--- a/distributed/src/CMakeLists.txt
+++ b/distributed/src/CMakeLists.txt
@@ -11,7 +11,8 @@ target_link_libraries(distributed
 if(ENABLE_CUFFT_MP AND Kokkos_ENABLE_CUDA)
   find_package(cuFFTMp REQUIRED)
   target_include_directories(distributed INTERFACE ${cuFFTMp_INCLUDE_DIRS})
-  # We link cuFFTMp before and after KokkosFFT to ensure that it will be linked before cuFFT
+  # We add cuFFTMp to the link libraries before and after KokkosFFT to ensure that cuFFTMp will
+  # appear before cuFFT on the linker command line
   target_link_libraries(distributed INTERFACE ${cuFFTMp_LIBRARIES})
   target_link_libraries(distributed INTERFACE KokkosFFT::fft)
   target_link_libraries(distributed INTERFACE ${cuFFTMp_LIBRARIES})

--- a/distributed/unit_test/CMakeLists.txt
+++ b/distributed/unit_test/CMakeLists.txt
@@ -25,11 +25,6 @@ endif()
 add_executable(unit-tests-mpi ${SOURCES})
 find_package(MPI REQUIRED COMPONENTS CXX)
 
-if(ENABLE_CUFFT_MP AND Kokkos_ENABLE_CUDA)
-    target_include_directories(unit-tests-mpi PUBLIC ${cuFFTMp_INCLUDE_DIRS})
-    target_link_libraries(unit-tests-mpi PUBLIC ${cuFFTMp_LIBRARIES})
-endif()
-
 target_compile_features(unit-tests-mpi PUBLIC cxx_std_17)
 target_compile_options(unit-tests-mpi PUBLIC -std=c++17)
 

--- a/examples/navier-stokes-MPI-batched/CMakeLists.txt
+++ b/examples/navier-stokes-MPI-batched/CMakeLists.txt
@@ -2,5 +2,5 @@ add_executable(navier-stokes-MPI-batched main.cpp)
 
 find_package(MPI REQUIRED COMPONENTS CXX)
 
-target_link_libraries(navier-stokes-MPI-batched PUBLIC MPI::MPI_CXX Kokkos::kokkos KokkosFFT::fft distributed)
+target_link_libraries(navier-stokes-MPI-batched PUBLIC MPI::MPI_CXX Kokkos::kokkos distributed)
 target_compile_features(navier-stokes-MPI-batched PUBLIC cxx_std_17)

--- a/examples/navier-stokes-MPI/CMakeLists.txt
+++ b/examples/navier-stokes-MPI/CMakeLists.txt
@@ -2,5 +2,5 @@ add_executable(navier-stokes-MPI main.cpp)
 
 find_package(MPI REQUIRED COMPONENTS CXX)
 
-target_link_libraries(navier-stokes-MPI PUBLIC MPI::MPI_CXX Kokkos::kokkos KokkosFFT::fft distributed)
+target_link_libraries(navier-stokes-MPI PUBLIC MPI::MPI_CXX Kokkos::kokkos distributed)
 target_compile_features(navier-stokes-MPI PUBLIC cxx_std_17)


### PR DESCRIPTION
When `cuFFT` is linked before `cuFFTMp`, the `cufftMpAttachComm` function fails with a `CUFFT_INVALID_PLAN` error. Adding `cuFFTMp` to the link libraries before and after `KokkosFFT::fft` (which adds `cuFFT`) ensures that `cuFFTMp` will be linked before `cuFFT`. 